### PR TITLE
Fix <div>, containing Element info

### DIFF
--- a/code/ElementBase.php
+++ b/code/ElementBase.php
@@ -127,8 +127,10 @@ class ElementBase extends DataObject implements CMSPreviewable
         if (ClassInfo::exists('Fluent'))
         {
             $locale = Fluent::alias(Fluent::current_locale());
-            $description .= ' – Locale: <span class="element-state element-state-'.$locale.'">'.$locale.'</span></div>';
+            $description .= ' – Locale: <span class="element-state element-state-'.$locale.'">'.$locale.'</span>';
         }
+
+        $description .= '</div>';
 
 
         $fields->addFieldsToTab('Root.Main', [


### PR DESCRIPTION
The div is left open when Fluent is not present.